### PR TITLE
Update the Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
+    google-protobuf (3.21.8)
     google-protobuf (3.21.8-x86_64-darwin)
     google-protobuf (3.21.8-x86_64-linux)
     html-proofer (4.4.3)
@@ -62,6 +63,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.8.1)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -91,6 +96,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
@@ -104,4 +110,4 @@ DEPENDENCIES
   sass-embedded
 
 BUNDLED WITH
-   2.3.8
+   2.3.9


### PR DESCRIPTION
This updates the Gemfile.lock after a recent local setup. Various gems are added or updated, and `ruby` is added as a platform