### PR TITLE
Fix related sidebar

### DIFF
--- a/src/_plugins/page_filters.rb
+++ b/src/_plugins/page_filters.rb
@@ -1,0 +1,24 @@
+module Jekyll
+  module PageFilters
+    def children_of(all_pages, parent)
+      all_pages.select { |p| child_of?(p, parent) }
+    end
+
+    def parent_of(all_pages, child)
+      all_pages.find { |p| child_of?(child, p) }
+    end
+
+    private
+
+    def child_of?(child, parent)
+      parent_url = parent.respond_to?("url") ? parent.url : parent["url"]
+      child_url = child.respond_to?("url") ? child.url : child["url"]
+
+      return false if parent_url == child_url
+
+      Regexp.new("^#{parent_url}/?[\\w\\-]+(\\.html|/)?$").match?(child_url)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::PageFilters)


### PR DESCRIPTION
`related_pages.html` was using a `children_of` filter, but this had not been added to the repo. Likewise, `related.html`, which includes `related_pages.html`, was using an unadded `parent_of` filter

These filters were added to the Playbook as public methods within a module in commit 3e9ad4c, and a similar piece of code can be found on a Stack Overflow answer

@see https://github.com/dxw/playbook/commit/3e9ad4cb498c577d34a18bbf8713f4e3410528c1
@see https://stackoverflow.com/a/66771463

The `children_of` filter is used to ensure that the related pages list only includes children of the current page. It also ensures the parent and child respond to `.url`, which presumably filters out stuff like (most) assets

The `parent_of` filter is used to provide a back link from a child page to its parent