### PR TITLE
Allow image upload

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -16,8 +16,6 @@ backend:
   repo: dxw/accessibility-manual
   branch: main
   open_authoring: true
-media_library:
-  name: disabled
 media_folder: _images
 publish_mode: editorial_workflow
 show_preview_links: true


### PR DESCRIPTION
The media library was disabled - this re-enables it, allowing content editors to upload images and include them in Markdown files

## Testing

You can test this locally:
1. Comment/uncomment the admin config (`src/admin/config.yml`) as instructed on lines 1-8
2. Load both servers
3. Click on "Edit this page"
4. Click on "Choose an image" - the media library should now load
5. Click on the "Upload" button - a file selection menu should appear