### PR TITLE
Add an Introduction to accessibility

### DIFF
--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -1,7 +1,8 @@
 ---
 title: Introduction to accessibility
 ---
-At dxw, our [mission](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission) is to build services that fit seamlessly into user's lives, and that make public services
+At dxw, our [mission](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission) is to build services
+that fit seamlessly into user's lives, and that make public services
 usable and accessible to all – especially those most in need.
 
 To achieve that mission, we must create services that work well for people with accessibility needs.
@@ -102,7 +103,7 @@ Assistive technology is not only used by disabled people. All people with access
 (if they have access to it and know how to use it).
 
 ## Why it is important to create services that work well for people with accessibility needs
-At dxw we want to make sure that everyone can access and use the digital services we create.
+At dxw we want to make sure that everyone can access and use the services we create.
 
 We do this because:
 * It is the right thing to do

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -1,0 +1,118 @@
+---
+title: Introduction to accessibility
+---
+At dxw, our [mission](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission) is to build services that fit seamlessly into user's lives, and that make public services
+usable and accessible to all – especially those most in need.
+
+To achieve that mission, we must create services that work well for people with accessibility needs.
+
+This guide explains:
+* what we mean by concepts like accessibility needs, disability and assistive technology
+* the different conceptual models of disability
+* why it is important for us create accessible services
+
+## What we mean by people with accessibility needs
+People with accessibility needs are people that have specific needs when accessing and using digital products and services
+at this point in their life.
+
+They may be members of the public directly using a service, people helping others to use a service, public servants
+supporting and operating services, or colleagues working along side us to create those services.
+
+Some will use assistive products to maintain or perform activities of daily living, like accessing a computer, eating, 
+communicating, etc.
+
+Accessibility needs can be a result of:
+
+* **Disability**: these may be cognitive, visual, auditory and movement disabilities, like learning disabilities, blindness,
+  deafness/Deafness or arthritis.
+* **Illness/disease/condition**: like long covid, Parkinson’s disease or menopause.
+* **Situational restrictions/inequity**: like not having a smartphone,
+  [not having an internet connection](https://www.ons.gov.uk/peoplepopulationandcommunity/householdcharacteristics/homeinternetandsocialmediausage/articles/exploringtheuksdigitaldivide/2019-03-04)
+  or not having sufficient digital confidence to perform some tasks.  
+
+## What we mean by disability
+Disability is one word attempting to describe lots of different experiences and stories.
+
+The [World Health Organisation](https://cdn.who.int/media/docs/default-source/classification/icf/icfbeginnersguide.pdf)
+states that disability is an umbrella term covering impairments, activity limitations
+and participation restrictions:
+* **Impairments** are a disruption/difference in body function and/or structure. 
+* **Activity** limitations are difficulties faced when trying to do a task or action.
+* **Participation** restrictions are challenges experienced when involved in life situations.
+
+About 15% of the human population has a disability
+([WeThe15](https://www.wethe15.org/?gclid=CjwKCAjw3ueiBhBmEiwA4BhspLqd1n_QXa2rqEQp-PnT04IVYx2A13O8VvrRddNMBoQmK-Wf5ES7SBoCWVkQAvD_BwE)).
+That is 1.2 billion of people in the world that have a physical, visual, hearing and/or cognitive disability.
+Often, people will experience more than one disability at any given time and their experience will be compounded by 
+chronic illnesses, mental health problems and other protected characteristics, like gender. 
+
+Disability is not static, and cannot be separated from human development
+([disability creation process](https://sjdr.se/articles/10.16993/sjdr.62#3-fundamentals-of-the-dcp)). It is
+individually and culturally defined and subjected to power dynamics.
+
+Disability can be experienced short term (for example, someone that just had an eye surgery and is in recovery) or
+long term and sometimes can be progressive (getting worse with time). This matters because we are designing digital
+products and services for users that may have disabilities that will last a short period of time or that will get worse
+with time, and we need to find ways of designing digital products for changing access needs.
+
+## Conceptual models of disability
+The way we think about disability determines how we define disability, how we understand the impact of disability and how
+we design products and services for people with disabilities.
+
+### Medical model
+This model promotes the idea that disability is caused by individual impairments and that disabled people are a collection of
+deficits, a minority and that they need to be diagnosed, cured, controlled and prevented. This model is flawed because it does
+not include non-medical aspects of disability, such as lived experiences, environment, society and intersectionality. For example,
+some people see disability as their identity and would not seek a cure.
+
+### Social model
+This model promotes the idea that society has a role in exacerbating or ameliorating the challenges faced by disabled people. For
+example, a socially hostile and discriminatory environment could be much more disabling than any individual disability. This model
+aims at reducing discrimination and injustice towards disabled people and it has been useful at supporting the development of
+public policies. This model is flawed because it does not include the individual disability (by focusing only on the disabling
+society) thus excluding impairments and disability identity.
+
+### Biopsychosocial model
+This model promotes the idea that disability is a combination of physical, emotional and environmental experiences. This model
+underpins the International Classification of Functioning, endorsed by the World Health Organisation. This model is flawed
+because it promotes an overly normative understanding of what is a ‘normal functioning body’.
+
+### Human rights model
+The United Nations Convention on the Rights of Persons with Disabilities (UNCRPD) promotes the idea that human interactions,
+attitudinal barriers and environmental barriers hinder the full and effective participation in society, and this results in
+disability.
+
+UNCRPD aims to ensure that people with disabilities have the same cultural, social, economic, political and civil
+rights as non-disabled.
+
+UNCRPD shifts disability conceptualization from a social welfare and medical concern to a human rights
+issue that admits that society’s barriers and prejudices are disabling. The aim of this model is to encourage disability policy.
+
+## What we mean by assistive technology
+Assistive technologies are products, systems and services that help people with accessibility needs to successfully access and
+use other products and service. Helping them to have independent, healthy and dignified lives, and participate in their
+communities and other aspects of life.
+
+Assistive products are external devices or software used by people to maintain or perform activities of daily living.
+3.5 billion people will need assistive technology by 2050 globally. Unfortunately, access to assistive products is not
+equitable and in some countries, only 3% of people have access to assistive products
+([assistive technology key facts](https://www.who.int/news-room/fact-sheets/detail/assistive-technology)).
+
+Assistive technology is not only used by disabled people. All people with accessibility needs may use assistive technology
+(if they have access to it and know how to use it).
+
+## Why it is important to create services that work well for people with accessibility needs
+At dxw we want to make sure that everyone can access and use the digital services we create.
+
+We do this because:
+* It is the right thing to do
+* To follow guidance set by the
+  [GOV.UK service manual](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction)
+* To meet accessibility requirements set by accessibility standards. Such as the
+  [Web Content Accessibility Guidelines (WCAG 2.2)](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag).
+* Under the [Human Rights Act](https://www.equalityhumanrights.com/human-rights/human-rights-act/article-14-protection-discrimination)
+  and the [UK Equality Act 2010](https://www.gov.uk/guidance/equality-act-2010-guidance#overview), discrimination is prohibited.
+  If our services are not accessible, users those services can claim that discrimination is taking place.
+* dxw contributes to [UN sustainable development goal number 10] set by the United Nations. Goal 10 aims to reduce
+  inequality within and among countries. At dxw, we contribute to this goal by helping to reduce
+  the unequal access to public services for people with accessibility needs.


### PR DESCRIPTION
Use the material from the introduction section in Zuleima's user research guide to create an introduction page for the Accessibility Manual.

There's some work to do to reconcile this with the manual's first page, but I think it will be easier to do that once the Introduction is in place.