### PR TITLE
Change nav section toggle to button

### DIFF
--- a/src/_includes/site_navigation.html
+++ b/src/_includes/site_navigation.html
@@ -9,9 +9,11 @@
             <a href="{{ section.url | relative_url }}" {% if section.url == page.url %}class="current" aria-current="page"{% endif %}>{{ section.title }}</a>
               {% assign grouped_related_pages = site.pages | children_of: section | group_by: "related_order" | sort: "name" %}
               {% if grouped_related_pages.size > 0 %}
-                <label class="visually-hidden" for="section-{{ forloop.index }}">Toggle pages in {{ section.title }}</label>
-                <input class="related__expand-toggle arrow" type="checkbox" name="section-{{ forloop.index }}" id="section-{{ forloop.index }}"
-                aria-controls="related-section-list-{{ forloop.index }}" {% if section.url == page.url or section.url == parent_page.url %}checked{% endif %}>
+                {% if section.url == page.url or section.url == parent_page.url %}{% assign is_expanded = true%}{% else %}{% assign is_expanded = false %}{% endif %}
+                <button type="button" class="related__expand-toggle arrow" aria-expanded="{{ is_expanded }}" aria-controls="related-section-list-{{ forloop.index }}" onclick="toggleAriaExpanded(event)">
+                  <span class="visually-hidden">{% if is_expanded == true %}Hide{% else %}Show{% endif %}</span>
+                  <span class="visually-hidden"> links in {{section.title}} category</span>
+                </button>
                 <ul class="related__section-list" id="related-section-list-{{ forloop.index }}">
                   {% for related_page_group in grouped_related_pages %}
                     {% assign related_pages = related_page_group.items | sort_natural: "title" %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -20,5 +20,6 @@
       {% include page-content.html %}
     </main>
     {% include contribute.html %}
+    <script src="/assets/main.js"></script>
   </body>
 </html>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -14,6 +14,9 @@
     <link rel="stylesheet" href="/assets/main.css" />
   </head>
   <body>
+    <script>
+      document.body.className += ' js-enabled';
+    </script>
     {% include navbar.html %}
     <main>
       {% include site_navigation.html %}

--- a/src/_sass/_related.scss
+++ b/src/_sass/_related.scss
@@ -54,6 +54,7 @@
   }
 
   .related__expand-toggle {
+    display: none;
     background-color: transparent;
     margin: 0;
   }
@@ -65,7 +66,6 @@
   .arrow {
     border: solid colours.$navy;
     border-width: 0 0.25em 0.25em 0;
-    display: inline-block;
     padding: 0.25em;
     transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
@@ -95,6 +95,12 @@
   .current {
     text-decoration: underline;
     text-decoration-thickness: 0.15em;
+  }
+}
+
+.js-enabled {
+  .related__expand-toggle {
+    display: inline-block;
   }
 }
 

--- a/src/_sass/_related.scss
+++ b/src/_sass/_related.scss
@@ -54,13 +54,11 @@
   }
 
   .related__expand-toggle {
-    -webkit-appearance: none;
-    appearance: none;
     background-color: transparent;
     margin: 0;
   }
 
-  .related__expand-toggle:checked ~ .related__section-list {
+  .related__expand-toggle[aria-expanded="true"] ~ .related__section-list {
     display: block;
   }
 
@@ -79,7 +77,7 @@
     top: 0.4em;
   }
 
-  .arrow:checked {
+  .arrow[aria-expanded="true"] {
     transform: rotate(-135deg);
     -webkit-transform: rotate(-135deg);
     top: 0.75em;

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -1,0 +1,7 @@
+function toggleAriaExpanded(e) {
+  const button = e.target
+  const isExpanded = button.getAttribute('aria-expanded') === 'false' ? true : false
+  
+  button.setAttribute('aria-expanded', isExpanded)
+  button.children[0].innerText = isExpanded ? 'Hide' : 'Show'
+}


### PR DESCRIPTION
Previously I used a form checkbox to toggle the expanded or collapsed state of the navigation section links - which meant that we did not need to use JavaScript.

However the trouble with using form elements is their longstanding association with the collection of data - and the use of a button with JavaScript would be more semantically correct. (Resolves issue #92 )

Here, replacing the use of a checkbox with a button, and adding a toggle function which is called on clicking the button to manage the `aria-expanded` state.

If a user does not have JavaScript enabled they will not be able to control the buttons to toggle the navigation sections.

In this case, hiding the buttons (and arrow graphic). The links for a section will be shown when a vistor is on the section page, or one of the pages in that section, but the user will not be able to expand and collapse links in other sections.

## Screenshots

Existing - screen with a side navigation with toggle buttons to expand and collapse the navigation sections:
![](https://github.com/dxw/accessibility-manual/assets/50752284/9c808d56-255d-4967-a3ef-4b20620939cb)


Screen with a side navigation without toggle buttons if JavaScript is not enabled:
![](https://github.com/dxw/accessibility-manual/assets/50752284/e9253be8-6044-4c42-9c1e-4d97c2f5e4dc)
