### PR TITLE
Add new guide to our accessibility obligations

### DIFF
--- a/src/introduction/obligations.md
+++ b/src/introduction/obligations.md
@@ -1,0 +1,132 @@
+---
+title: Accessibility obligations
+related_order: 100
+---
+
+At dxw, we create accessible services because it is the right thing to do, and because it is the law.
+
+## Moral obligations
+
+[Our mission](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission) is to build services
+that fit seamlessly into user’s lives, and that make public services usable and accessible to all – especially those most in need.
+
+[Our principles](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-principles) are to:
+
+* [Start with people and their needs](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#start-with-people-and-their-needs),
+  so we create public services that work well for everyone who depends on them
+* [Make everything we do accessible](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#make-everything-we-do-accessible),
+  to make sure that everyone can access the services we create
+
+By creating accessible services, we contribute to
+[United Nations sustainable development goal number 10](https://sdgs.un.org/goals/goal10#targets_and_indicators)
+through reducing unequal access to public services.
+
+## Accessibility regulations
+
+### Human Rights Act and Equality Act
+
+Under the [Human Rights Act 1998](https://www.legislation.gov.uk/ukpga/1998/42/contents) and the
+[Equality Act 2010](https://www.gov.uk/guidance/equality-act-2010-guidance), discrimination is prohibited,
+against disabled people and people with other protected characteristics.
+
+If our services are not accessible, users of those services can claim that discrimination is taking place.
+
+### Public Sector Equality Duty
+The Equality Act also creates the [Public Sector Equality Duty](https://www.gov.uk/government/publications/public-sector-equality-duty).
+This duty requires most of the organisations we work with to consider how their policies and decisions affect people who are
+protected under the Equality Act.
+
+The duty requires public authorities to:
+
+* eliminate unlawful discrimination
+* advance equality of opportunity
+* encourage good relations
+
+And to:
+
+* publish equality information to show how they’ve complied with the equality duty
+* prepare and publish equality objectives
+
+### Reasonable adjustments
+
+The Equality Act creates a duty for organisations to make reasonable adjustments to remove barriers for disabled people
+and people with other protected characteristics.
+
+The duty applies to barriers that place people at a substantial disadvantage. And covers both members of the public using services,
+and the staff and volunteers involved in providing services.
+
+The legislation gives no specific criteria for whether an adjustment is reasonable, or whether a disadvantage is substantial.
+
+For example:
+
+1. Expanding a local government advice service to support text chats as well as voice phone calls would
+   likely be consider a reasonable adjustment>
+
+   As people not able to make voice phone calls are at a substantial disadvantage and supporting text chat is
+   a relatively straightforward and affordable addition.
+
+1. A government agency has published an online archive of old information leaflets, posters, television information films
+   and radio adverts. Making the archive fully accessible would likely not be considered a reasonable adjustment.
+
+   As the disadvantage for disabled people might not be considered substantial, and the cost might be larger than the
+   current archive budget.
+
+1. Making the mapping features of a Land Registry web application fully accessible for local government staff who are blind
+   or have very low vision would likely not be considered a reasonable adjustment.
+
+   While some staff might be at a substantial disadvantage, making all the mapping features fully accessible would not be possible.
+
+[What are reasonable adjustments?](https://abilitynet.org.uk/workplace/what-are-reasonable-adjustments) by AbilityNet,
+has more about reasonable adjustments. 
+
+### Alternative channels and steps
+
+The Human Rights Act and Equality Act apply particularly to public services that are essential for people to live
+and take part in society. Those services cannot exclude some people because of their disability, or other characteristics or circumstances.
+
+However, we know that accessibility needs vary widely, and can conflict. And it is not always reasonable, or even possible,
+to make every part of every web page or web application fully accessible to everyone.
+
+So some services may need to provide alternative ways for people to access and use them.
+
+For example, to provide a passport photo you can:
+
+* have a friend or family member take your photo and upload the image file yourself
+* have a high street photographer take your photo and upload the image file for you
+* use a modern photo booth that takes your photo and uploads the image file automatically
+
+### Public Sector Bodies Accessibility Regulations
+The [Public Sector Bodies Accessibility Regulations 2018/2022](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
+require most public sector websites and mobile applications to:
+
+* meet the latest published version of the [Web Content Accessibility Guidelines (WCAG)](/standards/)
+* publish an accessibility statement
+
+The regulations apply to web content, web applications and mobile applications provided for members of the public.
+And to web content and web applications (‘intranets and extranets’) provided for staff.
+Mobile applications provided for staff and students are not covered.
+
+### Disproportionate burden
+
+Public sector bodies subject to the accessibility regulations can claim that making a website or mobile application
+fully accessible would be a disproportionate burden.
+
+Organisations may be able to support such a claim if making something fully accessible would take up a
+significant proportion of their budget, or if it would provide little benefit for disabled people.
+
+An organisation is less likely to be able to make such a claim if it
+provides services that are specifically aimed at disabled people, such as for claiming allowances or applying for a Blue Badge.
+Or if a service is essential for disabled people to live or take part in society, such as accessing a state pension or registering to vote.
+
+### The Service Standard
+
+Point 5 of the Service Standard requires us to
+[Make sure everyone can use the service](https://www.gov.uk/service-manual/service-standard/point-5-make-sure-everyone-can-use-the-service).
+
+When we are working to the Service Standard we have additional requirements to:
+
+* do user research with people with accessibility needs
+* test our services with common assistive technologies
+
+Our guides on [researching accessibility needs](/research/) and on [developing accessible services](/development/)
+can help you meet these requirements.

--- a/src/introduction/obligations.md
+++ b/src/introduction/obligations.md
@@ -5,6 +5,12 @@ related_order: 100
 
 At dxw, we create accessible services because it is the right thing to do, and because it is the law.
 
+This guide:
+
+* explains the [moral obligations](#moral-obligations) that we have set for ourselves in our mission and principles
+* identifies the [accessibility regulations](#accessibility-regulations) that apply to public sector services and content, and the obligations they place on us
+* explains terms like [reasonable adjustments](#reasonable-adjustments) and [disproportionate burden](#disproportionate-burden)
+
 ## Moral obligations
 
 [Our mission](https://playbook.dxw.com/about-us/our-mission-values-and-principles/#our-mission) is to build services

--- a/src/introduction/obligations.md
+++ b/src/introduction/obligations.md
@@ -99,7 +99,7 @@ For example, to provide a passport photo you can:
 The [Public Sector Bodies Accessibility Regulations 2018/2022](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
 require most public sector websites and mobile applications to:
 
-* meet the latest published version of the [Web Content Accessibility Guidelines (WCAG)](/standards/)
+* meet the latest published version of the [Web Content Accessibility Guidelines (WCAG)](/introduction/standards.md)
 * publish an accessibility statement
 
 The regulations apply to web content, web applications and mobile applications provided for members of the public.


### PR DESCRIPTION
Add a new guide that:
- explains why creating accessible services is the right thing to do
- identifies the accessibility regulations that apply to public sector services and content, and the obligations they place on us
- explains terms like reasonable adjustments and disproportionate burden