### PR TITLE
Remove dxwcom link from header nav

### DIFF
--- a/src/_includes/navbar.html
+++ b/src/_includes/navbar.html
@@ -1,5 +1,5 @@
 <header class="navbar">
-  <ul aria-label="Main navigation">
+  <ul>
     <li>
       <a class="navbar-title" href="/" aria-label="dxw Accessibility Manual Homepage"><img src="/assets/images/d-marque.png" role="presentation" alt="" /> dxw Accessibility Manual</a
       >

--- a/src/_includes/navbar.html
+++ b/src/_includes/navbar.html
@@ -1,11 +1,8 @@
 <header class="navbar">
   <ul aria-label="Main navigation">
     <li>
-      <a href="/" aria-label="dxw Accessibility Manual Homepage"><img src="/assets/images/d-marque.png" role="presentation" alt="" /> dxw Accessibility Manual</a
+      <a class="navbar-title" href="/" aria-label="dxw Accessibility Manual Homepage"><img src="/assets/images/d-marque.png" role="presentation" alt="" /> dxw Accessibility Manual</a
       >
-    </li>
-    <li>
-      <a href="https://www.dxw.com">dxw.com</a>
     </li>
     <li id="menu-button-item">
       <button class="icon-button" aria-expanded="false" aria-controls="site-navigation" onclick="toggleAriaExpanded(event, 'close', 'menu', 'site-navigation')">

--- a/src/_sass/_navbar.scss
+++ b/src/_sass/_navbar.scss
@@ -14,6 +14,13 @@ $height: 70px; // Manually measured after layout.
   font-family: typography.$heading-font-family;
   font-weight: typography.$heading-font-weight;
 
+  &-title {
+    font-size: 1rem;
+    @include breakpoints.on-large-screens {
+      font-size: inherit;
+    }
+  }
+
   a {
     display: flex;
     align-items: center;


### PR DESCRIPTION
- The change removes the link to dxw.com from the navbar for more space so that the title doesn't wrap on to 2 lines at smaller viewports.
- The title font size is set to 1rem to help text scale better on smaller viewports