### PR TITLE
Make subheadings short

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -1,5 +1,5 @@
 ---
-title: Creating accessible content
+title: Creating content
 navigation_order: 1
 tags:
   - Content

--- a/src/index.md
+++ b/src/index.md
@@ -33,8 +33,8 @@ Our [guide to accessibility standards](/introduction/standards) identifies and d
 
 We have guides to help each of our professions play their full part in making everything we do accessible:
 
-* [Researching accessibility needs](/research/)
-* [Designing accessible services](/interaction-design/)
-* [Developing accessible applications](/development/)
-* [Creating accessible content](/content/)
+* [Researching needs](/research/)
+* [Designing services](/interaction-design/)
+* [Developing applications](/development/)
+* [Creating content](/content/)
 


### PR DESCRIPTION
Takes out the word accessible from subheadings in content referring to navigation sections.