### PR TITLE
Add a custom navigation label for pages to shortened the names of the sections in the navigation

### DIFF
--- a/src/_includes/site_navigation.html
+++ b/src/_includes/site_navigation.html
@@ -23,8 +23,9 @@
                     {% for subsection in subsections_by_title %}
                       {% unless subsection.unrelatable %}
                         <li>
+                          {% if subsection.navigation_title %}{% assign navigation_label = subsection.navigation_title %}{% else %}{% assign navigation_label = subsection.title %}{% endif %}
                           <a href="{{ subsection.url }}" {% if subsection.url == page.url %}class="current" aria-current="page"{% endif %}>
-                            {{ subsection.title }}
+                            {{ navigation_label }}
                           </a>
                         </li>
                       {% endunless %}

--- a/src/_includes/site_navigation.html
+++ b/src/_includes/site_navigation.html
@@ -7,7 +7,8 @@
         {% assign sections_by_title = section_group.items | sort_natural: "title" %}
         {% for section in sections_by_title %}
           <li class="navigation__section-link">
-            <a href="{{ section.url | relative_url }}" {% if section.url == page.url %}class="current" aria-current="page"{% endif %}>{{ section.title }}</a>
+            {% if section.navigation_title %}{% assign navigation_label = section.navigation_title %}{% else %}{% assign navigation_label = section.title %}{% endif %}
+            <a href="{{ section.url | relative_url }}" {% if section.url == page.url %}class="current" aria-current="page"{% endif %}>{{ navigation_label }}</a>
               {% assign subsection_groups_by_navigation_order = site.pages | children_of: section | group_by: "navigation_order" | sort: "name" %}
               {% if subsection_groups_by_navigation_order.size > 0 %}
                 {% if section.url == page.url or section.url == parent_page.url %}{% assign is_expanded = true%}{% else %}{% assign is_expanded = false %}{% endif %}

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -27,6 +27,10 @@ collection_defaults: &collection_defaults
       name: title
       widget: string
       required: true
+    - label: Custom menu title
+      name: navigation_title
+      widget: string
+      required: false
     - label: Permalink
       name: permalink
       widget: hidden

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -1,5 +1,6 @@
 ---
-title: Creating content
+title: Creating accessible content
+navigation_title: Creating content
 navigation_order: 1
 tags:
   - Content

--- a/src/development/index.md
+++ b/src/development/index.md
@@ -1,5 +1,6 @@
 ---
-title: Developing services
+title: Developing accessible services
+navigation_title: Developing services
 navigation_order: 1
 tags:
   - Development

--- a/src/interaction-design/index.md
+++ b/src/interaction-design/index.md
@@ -1,5 +1,6 @@
 ---
-title: Designing services
+title: Designing accessible services
+navigation_title: Designing services
 navigation_order: 1
 tags:
   - Design


### PR DESCRIPTION
- The change restores the word "accessible" in the page section titles so that they make more sense when linked to from outside the manual. 
- To allow us to shorten the names of the sections in the navigation, an additional field is added in pages specifically for the navigation text. This is an optional field. If it's not filled, then the default text in navigation will be the page title.