### PR TITLE
Feat/add feedback banner

### DIFF
--- a/src/_includes/page-content.html
+++ b/src/_includes/page-content.html
@@ -1,5 +1,11 @@
 <article class="page-content">
   <div>
+    <div class="phase-banner">
+      <p class="phase-banner__content">
+        This is a new resource created by dxw – your <a href="https://docs.google.com/forms/d/e/1FAIpQLSffZZZ8ARLBxT0WIRK01JlREMrrWm-74pyeEoa6TqjnOImxUw/viewform" rel="noreferrer noopener" target="_blank">feedback (opens in a new tab)</a> will help us to improve it.
+      </p>
+    </div>
+
     <h1>{{ page.title }}</h1>
 
     {% assign stripped_content = content | strip %}

--- a/src/_sass/_banner.scss
+++ b/src/_sass/_banner.scss
@@ -1,0 +1,12 @@
+@use "./colours";
+@use "./typography";
+
+.phase-banner {
+    background-color: colours.$yellow-light;
+    font-family: typography.$heading-font-family;
+    font-weight: typography.$heading-font-weight;
+    font-size: 1rem;
+    display: flex;
+    padding: 0 1rem;
+    margin: 0.67em 0;
+}

--- a/src/_sass/all.scss
+++ b/src/_sass/all.scss
@@ -1,6 +1,7 @@
 @use "normalize.css";
 
 @use "./accessibility";
+@use "./banner";
 @use "./colours";
 @use "./contribute";
 @use "./layout";


### PR DESCRIPTION
This PR adds a feedback banner above the main content area of the manual with a link to a Google Form so that users can provide feedback on using the manual.

<img width="1322" alt="Screenshot 2024-04-25 at 15 40 27" src="https://github.com/dxw/accessibility-manual/assets/2226904/a981715f-8c51-491b-bc3c-fe1ea787fe08">
