### PR TITLE
Updating the contributing page name in navigation

### DIFF
--- a/src/contributing/index.md
+++ b/src/contributing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing to the dxw Accessibility Manual
-navigation_title: Contributing
+navigation_title: Contributing to the manual
 navigation_order: 2
 ---
 


### PR DESCRIPTION
Update the navigation name for the contributing page to add more meaningful context for users.

From 'Contributing' to 'Contributing to the manual'