### PR TITLE
Feature / 20268 change body font to Poppins

### DIFF
--- a/src/_sass/_typography.scss
+++ b/src/_sass/_typography.scss
@@ -1,6 +1,6 @@
 @use "./colours";
 
-$body-font-family: Cardo, serif;
+$body-font-family: Poppins, serif;
 $body-font-weight: 400;
 $body-font-weight-bold: 700;
 
@@ -8,14 +8,13 @@ $heading-font-family: Poppins, sans-serif;
 $heading-font-weight: 600;
 
 @import url("https://fonts.googleapis.com/css?family=Poppins:400,600&display=swap");
-@import url("https://fonts.googleapis.com/css?family=Cardo:400,700&display=swap");
 
 body {
   -moz-osx-font-smoothing: grayscale;
   font-family: $body-font-family;
   font-weight: $body-font-weight;
   font-size: 15pt;
-  line-height: 1.5;
+  line-height: 1.6;
   color: colours.$navy;
 }
 


### PR DESCRIPTION
Change body font from Cardo to Poppins to aid readability. As per https://dxw.zendesk.com/agent/tickets/20268